### PR TITLE
add support for auth method extension points

### DIFF
--- a/assets/view/add-server.html
+++ b/assets/view/add-server.html
@@ -21,6 +21,10 @@
         <input type="text" placeholder="" id="user">
         <label for="password">Password</label>
         <input type="password" placeholder="******" id="password">
+        <label for="authMethod">Authentication method</label>
+        <select id="authMethod">
+            {authMethods}
+        </select>
         <label for="socketTimeout">Socket Timeout (milliseconds)</label>
         <input type="text" placeholder="" id="socketTimeout" value="0">
         <label for="label">Label</label>
@@ -58,6 +62,7 @@
             const port = document.getElementById('port');
             const user = document.getElementById('user');
             const password = document.getElementById('password');
+            const authMethod = document.getElementById('authMethod');
             const socketTimeout = document.getElementById('socketTimeout');
             const label = document.getElementById('label');
             const tags = document.getElementById('tags');
@@ -106,6 +111,7 @@
                     label: label.value.trim(),
                     tags: tags.value.trim(),
                     uniqLabel: tags.value.trim() + ',' + label.value.trim(),
+                    authMethod: authMethod.value
                 }
             }
 
@@ -119,6 +125,7 @@
                     label.value = cfg.label;
                     tags.value = cfg.tags;
                     socketNoDelay.checked = cfg.socketNoDelay;
+                    authMethod.value = cfg.authMethod;
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -494,6 +494,7 @@
 			}
 		}
 	},
+	"q_auth_modules": [],
 	"devDependencies": {
 		"@finos/perspective": "^0.8.3",
 		"@finos/perspective-viewer": "^0.8.3",

--- a/src/client/component/add-server.ts
+++ b/src/client/component/add-server.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import { ColorThemeKind, Disposable, Uri, ViewColumn, WebviewPanel, window } from 'vscode';
 import { QCfg, QConnManager } from '../modules/q-conn-manager';
+import { authMethods } from '../modules/q-auth-method';
 import path = require('path');
 
 const templatePath = './assets/view';
@@ -130,8 +131,13 @@ export class AddServer implements Disposable {
         const dirUri = webview.asWebviewUri(dir);
         let template = fs.readFileSync(
             path.join(this._extensionPath, templatePath, 'add-server.html')).toString();
+        let authMethodsHTML = '';
+        for (let auth of authMethods) {
+            authMethodsHTML += '<option value="'+auth.id+'">'+auth.name+'</option>';
+        }
         template = template.replace(/{assets}/g, dirUri.toString())
-            .replace(/{theme}/g, this._theme);
+            .replace(/{theme}/g, this._theme)
+            .replace(/{authMethods}/g, authMethodsHTML);
         return template;
     }
 

--- a/src/client/modules/q-auth-method.ts
+++ b/src/client/modules/q-auth-method.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021 Morgan Stanley
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import * as q from 'node-q';
+
+export class AuthMethod {
+    id: string = "invalid";
+    name: string = "Invalid";
+
+    generateCredentials(params: q.ConnectionParameters): Promise<q.ConnectionParameters> {
+        throw "not implemented";
+    }
+
+}
+
+export class UserPasswordAuth extends AuthMethod {
+    id: string = "userPass";
+    name: string = "Username and Password";
+
+    generateCredentials(params: q.ConnectionParameters): Promise<q.ConnectionParameters> {
+        return Promise.resolve(params);
+    }
+}
+
+export let authMethods: AuthMethod[] = [new UserPasswordAuth()];
+
+for (let p of require('../../../package.json').q_auth_modules) {
+    require('./auth/'+p);
+}

--- a/src/client/modules/q-conn.ts
+++ b/src/client/modules/q-conn.ts
@@ -8,6 +8,7 @@
 import * as q from 'node-q';
 import { Command, TreeItem, TreeItemCollapsibleState } from 'vscode';
 import { QCfg, QConnManager } from './q-conn-manager';
+import { authMethods } from '../modules/q-auth-method';
 import path = require('path');
 
 export class QConn extends TreeItem {
@@ -16,6 +17,7 @@ export class QConn extends TreeItem {
     port: number;
     user: string;
     password: string;
+    authMethod: string;
     socketNoDelay: boolean;
     socketTimeout: number;
     conn?: q.Connection;
@@ -40,6 +42,7 @@ export class QConn extends TreeItem {
         this.conn = conn;
         this.tags = cfg.tags ?? '';
         this.uniqLabel = `${cfg.tags},${cfg.label}`;
+        this.authMethod = cfg.authMethod;
         this.command = {
             command: 'q-client.connect',
             title: 'connect to q server',
@@ -105,6 +108,14 @@ export class QConn extends TreeItem {
         }
     }
 
+    invokeAuth(): Promise<q.ConnectionParameters> {
+        for (let auth of authMethods) {
+            if (auth.id == this.authMethod) {
+                return auth.generateCredentials(this);
+            }
+        }
+        throw "unknown auth method: " + this.authMethod;
+    }
 
     contextValue = 'qconn';
 }


### PR DESCRIPTION
Add ability to define custom auth methods. The auth method is invoked immediately before opening the connection, so for example it could generate a token to be passed in the Password field. The token generation might be an async function. The default "Username and Password" auth method returns the connection properties unchanged.

© 2021 Morgan Stanley.
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE MIT License. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://github.com/jshinonome/vscode-q/blob/master/LICENSE.
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.