### PR TITLE
URGENT fix env-paths import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -597,7 +597,7 @@
 		"@types/picomatch": "^2.3.0",
 		"@typescript-eslint/eslint-plugin": "^5.11.0",
 		"csv-parser": "^3.0.0",
-		"env-paths": "^3.0.0",
+		"env-paths": "^2.2.1",
 		"eslint": "^8.8.0",
 		"fuse.js": "^6.5.3",
 		"graceful-fs": "^4.2.9",


### PR DESCRIPTION
Follow-up of https://github.com/jshinonome/vscode-q/pull/59

It seems that you've merged a version of PR before force-push ([ed60e23 ](https://github.com/jshinonome/vscode-q/commit/ed60e2374a943f3e18dff1c97b789ca52933986e) instead of [9ccbd3e](https://github.com/jshinonome/vscode-q/commit/9ccbd3e5cbb1bbd03e6dd3671bb42bcf9ea1fda7))

env-paths 3.0.0 depends on new nodejs and doesn't work on nodejs 14, despite declaring this. The resulting error is `Cannot find module 'node:path'`